### PR TITLE
fix: ignore errors when decoding message headers

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -133,7 +133,7 @@ readonly class Client
         $data = $response->getData(FetchData::class)[0] ?? throw new MessageNotFound();
 
         $rawHeaders = $data->getBodySection('HEADER')?->text ?? '';
-        $headers = iconv_mime_decode_headers($rawHeaders) ?: [];
+        $headers = iconv_mime_decode_headers($rawHeaders, ICONV_MIME_DECODE_CONTINUE_ON_ERROR) ?: [];
 
         if (null === $internalDate = $data->internalDate) {
             throw new Exception('Unable to fetch internal date from message '.$id);
@@ -169,7 +169,7 @@ readonly class Client
         $data = $response->getData(FetchData::class)[0] ?? throw new MessageNotFound();
 
         $rawHeaders = $data->getBodySection('HEADER')?->text ?? '';
-        return iconv_mime_decode_headers($rawHeaders) ?: [];
+        return iconv_mime_decode_headers($rawHeaders, ICONV_MIME_DECODE_CONTINUE_ON_ERROR) ?: [];
     }
 
     public function fetchBody(int $id): Part

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -104,6 +104,7 @@ class ClientTest extends TestCase
             MIME-Version: 1.0
             Date: Sat, 27 Apr 2024 20:49:48 +0200
             Message-ID: <CAMjJg5jatty9mNkfS871w6=oDqXGETmpT9Y6_b7vU8_vz_yYMw@example.com>
+            User-Agent: Mozilla/5.0 (Iâ?; CPU iPhone OS 5_0_1 like Mac OS X) AppleWebKit/534.46 (KHTML^C like Gecko) Version
             Subject: Lorem ipsum
             From: Sender <sender@localhost>
             To: User <user@localhost>
@@ -119,6 +120,7 @@ class ClientTest extends TestCase
             'MIME-Version' => '1.0',
             'Date' => 'Sat, 27 Apr 2024 20:49:48 +0200',
             'Message-ID' => '<CAMjJg5jatty9mNkfS871w6=oDqXGETmpT9Y6_b7vU8_vz_yYMw@example.com>',
+            'User-Agent' => 'Mozilla/5.0 (I?; CPU iPhone OS 5_0_1 like Mac OS X) AppleWebKit/534.46 (KHTML^C like Gecko) Version',
             'Subject' => 'Lorem ipsum',
             'From' => 'Sender <sender@localhost>',
             'To' => 'User <user@localhost>',


### PR DESCRIPTION
Added a flag for iconv_mime_decode_headers method to ignore malformed headers.
As stated by php documentation:
```
There are a lot of broken mail user agents that don't
follow the specification and don't produce correct MIME headers.
```